### PR TITLE
Use env in shebang line

### DIFF
--- a/exe/lobstersbot
+++ b/exe/lobstersbot
@@ -1,4 +1,4 @@
-#!/usr/local/bin/ruby -w
+#!/usr/bin/env -S ruby -w
 
 require 'lobstersbot'
 


### PR DESCRIPTION
Ruby can exist outside of /usr/local/ (and usually does), so use the `env` command to load the first one on `$PATH`.