### PR TITLE
Title grabbing plugin

### DIFF
--- a/exe/lobstersbot
+++ b/exe/lobstersbot
@@ -8,6 +8,7 @@ class Bot < Summer::Connection
   include Lobstersbot::Tell
   include Lobstersbot::Rss
   include Lobstersbot::Salute
+  include Lobstersbot::Title
 end
 
 Bot.new("irc.freenode.net")

--- a/lib/lobstersbot.rb
+++ b/lib/lobstersbot.rb
@@ -12,6 +12,7 @@ require 'lobstersbot/pluggable_connection'
 require 'lobstersbot/plugins/tell'
 require 'lobstersbot/plugins/rss'
 require 'lobstersbot/plugins/salute'
+require 'lobstersbot/plugins/title'
 
 module Lobstersbot
   class Error < StandardError; end

--- a/lib/lobstersbot/plugins/title.rb
+++ b/lib/lobstersbot/plugins/title.rb
@@ -1,0 +1,76 @@
+require 'net/http'
+
+require 'lobstersbot/plugins/title/wikipedia'
+require 'lobstersbot/plugins/title/lobsters'
+
+StopIteration = Class.new(StandardError)
+
+def parse_title(response)
+  nread = 0
+  title = nil
+
+  response.read_body do |chunk|
+    raise StopIteration if nread > 16_384
+
+    title = chunk[/<title>([^<]+)<\/title>/im, 1]&.strip
+    raise StopIteration if title
+
+    nread += chunk.length
+  end
+rescue StopIteration
+  title
+end
+
+def fetch(uri, limit = 10, &block)
+  # Avoid redirect loops
+  return unless limit > 0
+
+  request = Net::HTTP::Get.new uri
+  Net::HTTP.start(uri.host, uri.port, use_ssl: (uri.scheme == 'https'),
+                  open_timeout: 5, read_timeout: 5) do |http|
+    http.request(request) do |response|
+      case response
+      when Net::HTTPSuccess then return block.call(response)
+      when Net::HTTPRedirection then return fetch(URI(response['location']), limit - 1, &block)
+      end
+    end
+  end
+end
+
+module Lobstersbot
+  module Title
+    HANDLERS = [
+      WikipediaHandler.new,
+      LobstersHandler.new,
+    ].freeze
+
+    def get_title(channel, message)
+      uri = message[0]
+
+      # Find whether we can display special information for this title.
+      match = nil
+      handler = HANDLERS.find do |h|
+        match = uri.match(h.class::REGEXP)
+        !match.nil?
+      end
+
+      if handler.nil?
+        # Just a simple title grab.
+        uri = URI(uri)
+        title = fetch(uri) {|response| parse_title(response) }
+        unless title.nil?
+          privmsg("[ #{title} ] - #{uri.host}", channel)
+        end
+      else
+        # Special title data.
+        response = handler.handle(match)
+        privmsg(response, channel)
+      end
+    end
+
+    def self.included(mod)
+      handle = ->(bot, channel, _nick, message) { bot.get_title(channel, message) }
+      mod.add_trigger(10, URI::DEFAULT_PARSER.make_regexp, handle)
+    end
+  end
+end

--- a/lib/lobstersbot/plugins/title/lobsters.rb
+++ b/lib/lobstersbot/plugins/title/lobsters.rb
@@ -1,0 +1,42 @@
+require 'uri'
+require 'json'
+
+module Lobstersbot
+  module Title
+    class LobstersHandler
+      REGEXP = /lobste\.rs\/s\/(?<story>[^\/#]+)(?:.*#c_(?<comment>.*))?/i.freeze
+      LIMIT = 250
+
+      def strip_html(s)
+        # https://gist.github.com/awesome/225181
+        s.gsub(/<\/?[^>]*>/, "").gsub("\n", " ")
+      end
+
+      def plural(n)
+        n == 1 ? "" : "s"
+      end
+
+      def handle(match)
+        raw_data = fetch(URI("https://lobste.rs/s/#{match[:story]}.json"), &:body)
+        story = JSON.parse raw_data
+
+        if match[:comment]
+          comment = story['comments'].find {|c| c['short_id'] == match[:comment] }
+          unless comment.nil?
+            body = strip_html(comment['comment'])[0..LIMIT-1]
+            return "[Comment on https://lobste.rs/s/#{match[:story]}/] " +
+                   "#{body.strip}#{body.length == LIMIT ? '...' : ''}"
+          end
+        end
+
+        title = story['title']
+        submitter = story['submitter_user']['username']
+        score = story['score']
+        comments = story['comment_count']
+
+        return "[Story] #{title} (via #{submitter}, #{score} point#{plural(score)}, " +
+               "#{comments} comment#{plural(comments)})"
+      end
+    end
+  end
+end

--- a/lib/lobstersbot/plugins/title/wikipedia.rb
+++ b/lib/lobstersbot/plugins/title/wikipedia.rb
@@ -1,0 +1,46 @@
+require 'wikipedia'
+
+module Lobstersbot
+  module Title
+    class WikipediaHandler
+      REGEXP = /wikipedia\.org\/wiki\/(?<article>[^#]+)(?:#(?<section>.+))?/i.freeze
+      LENGTH = 250
+
+      def get_summary(page, match)
+        # Return from the article start if no section was specified.
+        regular_summary = page.text[0..LENGTH-1].gsub "\n", " "
+        return regular_summary unless match[:section]
+
+        # Find the section
+        section_name = match[:section].gsub "_", " "
+        section_header = page.text.index(/=+\s*#{section_name}\s*=+\n/)
+        return regular_summary unless section_header
+
+        # Find the start of the text for the section.
+        section_start = page.text.index("\n", section_header)
+        return regular_summary unless section_header
+
+        # Cut before the next section
+        next_section = page.text.index("\n=", section_start)
+        if next_section
+          length = [next_section - section_start, LENGTH].min
+        else
+          length = LENGTH
+        end
+
+        return page.text[(section_start+1)..(section_start+length)].gsub "\n", " "
+      end
+
+      def handle(match)
+        page = Wikipedia.find(match[:article])
+        return unless page
+
+        summary = get_summary page, match
+        title = match[:article]
+        if match[:section] then title << "##{match[:section]}" end
+
+        return "[WIKIPEDIA #{title}] #{summary.strip}#{summary.length >= LENGTH ? '...' : ''}"
+      end
+    end
+  end
+end

--- a/lobstersbot.gemspec
+++ b/lobstersbot.gemspec
@@ -33,4 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'summer', '~> 1.0'
   spec.add_runtime_dependency 'timers', '~> 4.1'
   spec.add_runtime_dependency 'rss', '~> 0.2.9'
+
+  # URL fetching dependencies
+  spec.add_runtime_dependency 'wikipedia-client', '~> 1.10.0'
 end

--- a/spec/lobstersbot/title/lobsters_handler_spec.rb
+++ b/spec/lobstersbot/title/lobsters_handler_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe Lobstersbot::Title::LobstersHandler do
+  subject { Lobstersbot::Title::LobstersHandler.new }
+
+  describe '#handle' do
+    it 'returns story details' do
+      result = subject.handle({ story: "jg3eet" })
+      expect(result).to eq("[Story] Lobsters by mail (via jcs, 33 points, 9 comments)")
+    end
+
+    it 'returns comment excerpt' do
+      result = subject.handle({ story: "jg3eet", comment: "llnoto" })
+      expect(result).to eq(
+        "[Comment on https://lobste.rs/s/jg3eet/] Well, lobsters just got a whole hell " +
+        "of lot cooler. This will even make it easier to reply on your phone.")
+    end
+  end
+end

--- a/spec/lobstersbot/title/wikipedia_handler_spec.rb
+++ b/spec/lobstersbot/title/wikipedia_handler_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+RSpec.describe Lobstersbot::Title::WikipediaHandler do
+  subject { Lobstersbot::Title::WikipediaHandler.new }
+
+  describe '#handle' do
+    it 'returns article summary' do
+      result = subject.handle({ article: "Hacker_News" })
+      # rubocop:disable Style/StringConcatenation
+      expect(result).to eq(
+        "[WIKIPEDIA Hacker_News] Hacker News is a social news website focusing "+
+        "on computer science and entrepreneurship. It is run by Paul Graham's "+
+        "investment fund and startup incubator, Y Combinator. In general, "+
+        "content that can be submitted is defined as \"anything that "+
+        "gratifies o...")
+      # rubocop:enable Style/StringConcatenation
+    end
+
+    it 'returns section summary' do
+      result = subject.handle({ article: "Hacker_News", section: "Vision_and_practices" })
+      # rubocop:disable Style/StringConcatenation
+      expect(result).to eq(
+        "[WIKIPEDIA Hacker_News#Vision_and_practices] The intention was to recreate "+
+        "a community similar to the early days of Reddit. However, unlike Reddit where "+
+        "new users can immediately both upvote and downvote content, Hacker News does "+
+        "not allow users to downvote content until they have accumulated 5...")
+      # rubocop:enable Style/StringConcatenation
+    end
+
+    it 'avoids returning multiple sections' do
+      result = subject.handle({ article: "Bubble_sort", section: "Pseudocode_implementation" })
+      expect(result).to eq(
+        "[WIKIPEDIA Bubble_sort#Pseudocode_implementation] In pseudocode the algorithm can " +
+        "be expressed as (0-based array):")
+    end
+  end
+end

--- a/spec/lobstersbot/title_spec.rb
+++ b/spec/lobstersbot/title_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+require 'uri'
+
+RSpec.describe Lobstersbot::Title do
+  subject { klass.new }
+
+  let(:klass) do
+    Class.new do
+      include Lobstersbot::PluggableConnection
+      include Lobstersbot::Title
+    end
+  end
+
+  describe '#fetch' do
+    it 'fetches titles' do
+      title = fetch(URI("https://lobste.rs/")) {|r| parse_title(r) }
+      expect(title).to eq("Lobsters")
+    end
+
+    it 'avoids redirect loops' do
+      title = fetch(
+        URI("https://demo.cyotek.com/features/redirectlooptest.php")) {|r| parse_title(r) }
+      expect(title).to be_nil
+    end
+  end
+
+  # XXX: Should this be disabled? Apparently it's bad style
+  # (https://github.com/rubocop-hq/rspec-style-guide#dont-stub-subject)
+  # but I can't find a better way to expect messages on privmsg.
+  # rubocop:disable RSpec/SubjectStub
+  describe '#get_title' do
+    it 'parses titles from messages' do
+      expect(subject).to receive(:privmsg).with("[ Lobsters ] - lobste.rs", "#channel")
+      subject.channel_message({ nick: "source" }, "#channel", "test https://lobste.rs/ test test")
+    end
+
+    it 'expects URL scheme' do
+      expect(subject).not_to receive(:privmsg)
+      subject.channel_message({ nick: "source" }, "#channel", "test lobste.rs test test")
+    end
+
+    it 'handles specialized URLs' do
+      # rubocop will stretch the string and then complain about line length.
+      # rubocop:disable Style/StringConcatenation
+      excerpt = "[WIKIPEDIA Freenode] freenode, formerly known as Open Projects Network, " +
+                "is an IRC network used to discuss peer-directed projects. Their servers " +
+                "are accessible from the host names chat.freenode.net, which load balances " +
+                "connections by using the actual servers in rotation...."
+      # rubocop:enable Style/StringConcatenation
+      expect(subject).to receive(:privmsg).with(excerpt, "#channel")
+      subject.channel_message({ nick: "source" }, "#channel",
+                              "test https://en.wikipedia.org/wiki/Freenode test")
+    end
+  end
+  # rubocop:enable RSpec/SubjectStub
+end


### PR DESCRIPTION
Title grabbing plugin with its own plugins for special URL handling. Currently has two plugins:

1. Wikipedia, with support for referencing a section
```
<sin-ack> https://en.wikipedia.org/wiki/Freenode
<lobstersbot> [WIKIPEDIA Freenode] freenode, formerly known as Open Projects Network, is an IRC network used to discuss peer-directed projects. Their servers are accessible from the host names chat.freenode.net, which load balances connections by using the actual servers in rotation....
<sin-ack> https://en.wikipedia.org/wiki/Freenode#Characteristics
<lobstersbot> [WIKIPEDIA Freenode#Characteristics] freenode is centrally managed. Staffers or staff (as IRC operators are called) have the same access across all servers. A list of active staff can be viewed using the /stats p command. Some operations that would normally only apply to one server (lik...
```
2. Lobsters stories and comments
```
<sin-ack> https://lobste.rs/s/jg3eet/
<lobstersbot> [Story] Lobsters by mail (via jcs, 33 points, 9 comments)
<sin-ack> https://lobste.rs/s/jg3eet/#c_llnoto
<lobstersbot> [Comment on https://lobste.rs/s/jg3eet/] Well, lobsters just got a whole hell of lot cooler. This will even make it easier to reply on your phone.
```

Otherwise, it simply grabs the title:
```
<sin-ack> https://lobste.rs/
<lobstersbot> [ Lobsters ] - lobste.rs
```