### PR TITLE
Limit link titles to 200 characters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,12 +15,22 @@ const config = new URL(process.argv.pop());
 const client = new IRC.Client();
 const storage = level('storage.leveldb');
 
+const maxTitleSize = 200;
+
 var timers = {};
+
+const truncate = (inputStr, len) => {
+  shortenedStr = inputStr.slice(0, len);
+  if (shortenedStr.length < inputStr.length) {
+    shortenedStr += "…";
+  }
+  return shortenedStr;
+}
 
 const fetchTitle = async (targetUrl) => {
   const { body: html, url } = await got(targetUrl);
-  const { title } = await metascraper({ html, url });  
-  return title;
+  const { title } = await metascraper({ html, url });
+  return truncate(title, maxTitleSize);
 };
 
 const injectLoggerMiddleware = (baseLogger) => {


### PR DESCRIPTION
I figured a nefarious user could put some super-long string in their site's metadata and cause the bot to spam the channel. [irc-framework seems to happily split up the message into 500-byte chunks and send them all with no limit](https://github.com/kiwiirc/irc-framework/blob/672d79257248de739777580bef5c0a455c405aae/src/client.js#L389). So it's a low risk with low impact, but better safe than sorry :)