### PR TITLE
Handle connection closure

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,6 +101,10 @@ client.on('leave', (event) => {
 })
 
 client.on('kick', (event) => {
+  if (config.username !== event.kicked) {
+    return
+  }
+
   event.logger.info('Deactivating scheduled tasks.', {action: 'kick'})
   timers[event.channel].map(timer => clearInterval(timer))
   delete timers[event.channel]


### PR DESCRIPTION
Handle the connection to the IRC server closing by cleanly closing DB connection and exiting the process. Changed scheduled event deactivation logic as events were not being reactivated on rejoining a room. Added kick handler to deactivate scheduled events for the channel mockturtle was kicked from.
