### PR TITLE
feat: added auto info when mentioning invite and fix join bug

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -17,6 +17,39 @@ const autoTitle = (event) => {
 }
 autoTitle.__match__ = /.*(?<url>https?:\/\/\S+).*/g
 
+const autoInviteInfo = (event) => {
+  const fun = async () => {
+    try {
+      const lastJoined = await event.database.get(`lastJoined/${event.target}/${event.nick}`);
+
+      if (Date.now() - Date.parse(lastJoined) < 600000) {
+        event.reply(`Looking for an invitation ${event.nick}? ` +
+          "https://lobste.rs/about#invitations " +
+          "has an intro, and " +
+          "https://lobste.rs/chat " +
+          "explains some expectations for this channel. " +
+          "(I am the channel bot.)"
+        )
+      }
+    } catch(e) {
+      if (e.notFound) {
+        /* bot missed a channel join, default to now, then re-trigger */
+        try {
+          await event.database.put(`lastJoined/${event.channel}/${event.nick}`, new Date().toString())
+          autoInviteInfo(event);
+        } catch (e) {
+          event.logger.error(e)
+        }
+      } else {
+        event.logger.error(e)
+      }
+    }
+  }
+
+  fun()
+}
+autoInviteInfo.__match__ = /.*invit(e|ation)s?.*/gm
+
 const help = (event) => {
   const { groups: { query } } = help.__match__.exec(event.message)
 
@@ -146,6 +179,7 @@ watch.__match__ = /^.+/g
 
 module.exports = [
   autoTitle,
+  autoInviteInfo,
   help,
   peek,
   salute,

--- a/src/index.js
+++ b/src/index.js
@@ -106,11 +106,22 @@ client.on('close', (event) => {
 })
 
 client.on('join', (event) => {
-  event.logger.info('Activating scheduled tasks.')
-  event.reply = (message) => client.channel(event.channel).say(message)
+  if (event.nick != client.user.nick) {
+    const fun = async () => {
+      try {
+        await event.database.put(`lastJoined/${event.channel}/${event.nick}`, new Date().toString())
+      } catch (e) {
+        event.logger.error(e)
+      }
+    }
+    fun()
+  } else {
+    event.logger.info('Activating scheduled tasks.')
+    event.reply = (message) => client.channel(event.channel).say(message)
 
-  if (timers[event.channel] === undefined) {
-    timers[event.channel] = scheduled.map(fn => setInterval(fn, fn.__interval__, event))
+    if (timers[event.channel] === undefined) {
+      timers[event.channel] = scheduled.map(fn => setInterval(fn, fn.__interval__, event))
+    }
   }
 })
 


### PR DESCRIPTION
Tasks were logged as 'activating' on every user join despite not actually running, regardless of whether or the joining user was mockturtle. Also a related minor performance note is that
```js
event.reply = (message) => client.channel(event.channel).say(message)
```
was being re-assigned on every user join, meaning that a new function was being created each time.

Information is printed according to #12 when mentioning `/invit(e|ation)s?/` within 10 minutes of joining.